### PR TITLE
Fix json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt-browserify": "^3.5.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-less": "^1.0.1",
-    "grunt-contrib-watch": "^0.6.1"
+    "grunt-contrib-watch": "^0.6.1",
     "highlight.js": "^8.4.0"
   },
   "author": "Daniel Gooß",


### PR DESCRIPTION
Fixes a json syntax error, preventing npm from reading dependencies.
